### PR TITLE
fix a bug in fee token refund

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -662,7 +662,10 @@ func (app *BaseApp) runTx(mode runTxMode, txBytes []byte, tx sdk.Tx) (result sdk
 
 		// Refund unspent fee
 		if app.feeRefundHandler != nil {
-			app.feeRefundHandler(originalCtx, tx, result)
+			err := app.feeRefundHandler(originalCtx, tx, result)
+			if err != nil {
+				result = sdk.ErrOutOfGas(err.Error()).Result()
+			}
 		}
 	}()
 

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -644,7 +644,7 @@ func (app *BaseApp) runTx(mode runTxMode, txBytes []byte, tx sdk.Tx) (result sdk
 	// meter so we initialize upfront.
 	var gasWanted int64
 	ctx := app.getContextForAnte(mode, txBytes)
-	originalCtx := ctx
+	ctxWithNoCache := ctx
 	defer func() {
 		if r := recover(); r != nil {
 			switch rType := r.(type) {
@@ -658,13 +658,15 @@ func (app *BaseApp) runTx(mode runTxMode, txBytes []byte, tx sdk.Tx) (result sdk
 		}
 
 		result.GasWanted = gasWanted
-		result.GasUsed = ctx.GasMeter().GasConsumed()
+		result.GasUsed = ctxWithNoCache.GasMeter().GasConsumed()
 
 		// Refund unspent fee
 		if app.feeRefundHandler != nil {
-			err := app.feeRefundHandler(originalCtx, tx, result)
+			err := app.feeRefundHandler(ctxWithNoCache, tx, result)
 			if err != nil {
-				result = sdk.ErrOutOfGas(err.Error()).Result()
+				result = sdk.ErrInternal(err.Error()).Result()
+				result.GasWanted = gasWanted
+				result.GasUsed = ctxWithNoCache.GasMeter().GasConsumed()
 			}
 		}
 	}()
@@ -684,7 +686,7 @@ func (app *BaseApp) runTx(mode runTxMode, txBytes []byte, tx sdk.Tx) (result sdk
 		}
 		if !newCtx.IsZero() {
 			ctx = newCtx
-			originalCtx = newCtx
+			ctxWithNoCache = newCtx
 		}
 
 		gasWanted = anteResult.GasWanted
@@ -701,7 +703,6 @@ func (app *BaseApp) runTx(mode runTxMode, txBytes []byte, tx sdk.Tx) (result sdk
 
 	ctx = ctx.WithMultiStore(msCache)
 	result = app.runMsgs(ctx, msgs)
-	result.GasWanted = gasWanted
 
 	// only update state if all messages pass and we're not in a simulation
 	if result.IsOK() && mode != runTxModeSimulate {

--- a/types/handler.go
+++ b/types/handler.go
@@ -6,4 +6,4 @@ type Handler func(ctx Context, msg Msg) Result
 // AnteHandler authenticates transactions, before their internal messages are handled.
 // If newCtx.IsZero(), ctx is used instead.
 type AnteHandler func(ctx Context, tx Tx) (newCtx Context, result Result, abort bool)
-type FeeRefundHandler func(ctx Context, tx Tx, result Result)
+type FeeRefundHandler func(ctx Context, tx Tx, result Result) error


### PR DESCRIPTION
Currently fee token refund process also cost gas. If gas is not enough here, there will be a panic, and no panic recover can handle this panic. As a result, the program will be crash. Besides, It is not reasonable to consume users' gas here:
* 1. Fee refund process is compensation for previous fee deduction. In ante handle, the whole fee has been deducted, which is just in case user can't pay transaction fee
* 2. The refund fee is based on gas used. If we continue consume gas, we can't work out refund fee.

So here, in refund process, new consumed gas is ignored. In addition, to avoid out of gas, I reset the context gas limit.
```
ctx = ctx.WithGasMeter(sdk.NewGasMeter(stdTx.Fee.Gas))
```