### PR TITLE
R4R: Fix fuxi-3000 consensus failure

### DIFF
--- a/x/stake/keeper/slash.go
+++ b/x/stake/keeper/slash.go
@@ -62,14 +62,14 @@ func (k Keeper) Slash(ctx sdk.Context, pubkey crypto.PubKey, infractionHeight in
 	remainingSlashAmount := slashAmount
 
 	switch {
-	case infractionHeight > ctx.BlockHeight():
+	case infractionHeight > ctx.BlockHeight() + 1:
 
 		// Can't slash infractions in the future
 		panic(fmt.Sprintf(
 			"impossible attempt to slash future infraction at height %d but we are at height %d",
 			infractionHeight, ctx.BlockHeight()))
 
-	case infractionHeight == ctx.BlockHeight():
+	case infractionHeight == ctx.BlockHeight() || infractionHeight == ctx.BlockHeight() + 1:
 
 		// Special-case slash at current height for efficiency - we don't need to look through unbonding delegations or redelegations
 		logger.Info(fmt.Sprintf(


### PR DESCRIPTION
According to my analysis, I think the main reasons of the consensus failure of fuxi-3000 are as follows:
* Due the there is not enough voting power at the start of the network, the network has been stucked for a long time. So the double sign evidence has been broadcasted to almost all nodes. Once voting power is enough, then the evidenve will be included in the first block. 
* Then each node attempts to apply this block. In beginBlock, the evidence will invoke slashing. However, in this situation, `infractionHeight` is 1 and `ctx.BlockHeight()` is 0. Then panic error happened.

Besides, when a validator is new added and it launchs double sign attack in the first block after it become a real validator. Then the double sign evidence happen to be included by the block proposal, then in the `beginBlock`, we will try to slash a validator which has no sign info. However, the sign info is required for figuring out the jail period. This [panic error](https://github.com/irisnet/cosmos-sdk/blob/5bc397d7bb3abe77a83a74b38d3c5f0d7a755341/x/slashing/keeper.go#L55) is just for checking the existence of validator sign info.
But this situation is possible and reasonable, we can't just panic, instead we should check the sign info of a validator before slashing it.